### PR TITLE
Adding Integration and Unit Auth tests and few bug fixes

### DIFF
--- a/src/main/java/com/stephensalano/fileflow_api/controllers/AuthController.java
+++ b/src/main/java/com/stephensalano/fileflow_api/controllers/AuthController.java
@@ -168,7 +168,7 @@ public class AuthController {
     public ResponseEntity<Map<String, Object>> login(
             @Valid @RequestBody AuthRequest authRequest
             ){
-        log.info("Lgin attempt for: {}", authRequest.usernameOrEmail());
+        log.info("Login attempt for: {}", authRequest.usernameOrEmail());
 
         try{
             AuthResponse authResponse = authService.login(authRequest);

--- a/src/main/java/com/stephensalano/fileflow_api/dto/requests/RegisterRequest.java
+++ b/src/main/java/com/stephensalano/fileflow_api/dto/requests/RegisterRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Size;
 
 public record RegisterRequest(
         @NotBlank(message = "Email cannot be blank")
-        @Email(regexp = "^(?=.{1,64}@)[A-Za-z0-9_-+]+(\\\\.[A-Za-z0-9_-+]+)*@[^-][A-Za-z0-9-+]+(\\\\.[A-Za-z0-9-+]+)*(\\\\.[A-Za-z]{2,})$")
+        @Email
         String email,
 
         @NotBlank(message = "Username must not be blank")
@@ -15,7 +15,7 @@ public record RegisterRequest(
 
         @NotBlank(message = "Password field must not be blank")
         @Size(min = 8, max = 20, message = "Password must be between 8 to 20 characters")
-        @Pattern(regexp =  "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%^&+=])(?=\\S+$).{8,20}$",
+        @Pattern(regexp =  "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&+=])(?=\\S+$).{8,20}$",
         message = "Password must contain at least one digit, one lowercase letter, one uppercase character and no whitespace")
         String password,
 

--- a/src/main/java/com/stephensalano/fileflow_api/entities/Account.java
+++ b/src/main/java/com/stephensalano/fileflow_api/entities/Account.java
@@ -37,7 +37,7 @@ public class Account implements UserDetails {
 
     @Column(nullable = false)
     @NotBlank(message = "Email cannot be blank")
-    @Email(regexp = "^(?=.{1,64}@)[A-Za-z0-9_-+]+(\\\\.[A-Za-z0-9_-+]+)*@[^-][A-Za-z0-9-+]+(\\\\.[A-Za-z0-9-+]+)*(\\\\.[A-Za-z]{2,})$")
+    @Email
     private String email;
 
     @Column(nullable = false)

--- a/src/test/java/com/stephensalano/fileflow_api/controllers/AuthControllerLoginUnitTest.java
+++ b/src/test/java/com/stephensalano/fileflow_api/controllers/AuthControllerLoginUnitTest.java
@@ -1,0 +1,106 @@
+package com.stephensalano.fileflow_api.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stephensalano.fileflow_api.configs.security.JwtService;
+import com.stephensalano.fileflow_api.dto.requests.AuthRequest;
+import com.stephensalano.fileflow_api.dto.responses.AuthResponse;
+import com.stephensalano.fileflow_api.services.auth.AuthService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+/**
+ * What are we testing?
+ * - We want to simulate a POST to /api/v1/auth/login with a JSON body like:
+ *
+ *  `{
+ *       "usernameOrEmail": "testuser",
+ *       "password": "Password123@"
+ *  }`
+ *
+ * In a happy path, we mock authService.login(...) to return an AuthResponse with known values
+ * We then verify:
+ * 1. HTTP status is 200 OK
+ * 2. Response has content-type: application/json
+ * 3. JSON body has exactly the fields we expect, with the values we stubbed
+ */
+@WebMvcTest(AuthController.class) // spins up only the web layer for AuthController
+public class AuthControllerLoginUnitTest {
+
+    /**
+     * Auth controller, depends on AuthService for login logic
+     * We mock it so we control what authService.login(...) returns
+     */
+    @MockitoBean
+    private AuthService authService;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    /**
+     * To simulate HTTP requests
+     */
+    @Autowired
+    private MockMvc mockMvc;
+
+    /**
+     * To convert out Java Login request POJO into JSON
+     */
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @WithMockUser // This makes Spring treat the request as "authenticated"
+    void login_WithvalidCredentials_ShouldReturnAuthResponse() throws Exception {
+        // 1. Arrange: build a sample AuthRequest
+        AuthRequest loginRequest = new AuthRequest(
+                "testuser",
+                "Password123@"
+        );
+
+        // 2. Create a fake AuthResponse, using the static factory that sets token_type = "Bearer "
+        AuthResponse fakeResponse = AuthResponse.of(
+                "fakeAccessToken.jwt.part",
+                "fakeRefreshToken.jwt.part",
+                3600,
+                "testuser",
+                "test@example.com",
+                "USER"
+        );
+
+        // 3. Stub AuthService.login(...) to return fake response
+        when(authService.login(any(AuthRequest.class))).thenReturn(fakeResponse);
+
+        // 4. Act: perform POST /api/v1/auth/login with JSON body
+        mockMvc.perform(
+                post("/api/v1/auth/login")
+                        .with(csrf()) // Add CSRF token to bypass Spring Security's CSRF protection
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest))
+        )
+                // 5. Assert: HTTP 200 OK
+                .andExpect(status().isOk())
+                // 6. Content-type must still be application/json
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                // 7. Verify each JSON property exactly as in AuthResponse:
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("Login successful"))
+                .andExpect(jsonPath("$.data.access_token").value("fakeAccessToken.jwt.part"))
+                .andExpect(jsonPath("$.data.refresh_token").value("fakeRefreshToken.jwt.part"))
+                .andExpect(jsonPath("$.data.token_type").value("Bearer "))
+                .andExpect(jsonPath("$.data.expires_in").value(3600))
+                .andExpect(jsonPath("$.data.username").value("testuser"))
+                .andExpect(jsonPath("$.data.email").value("test@example.com"))
+                .andExpect(jsonPath("$.data.role").value("USER"));
+    }
+
+}

--- a/src/test/java/com/stephensalano/fileflow_api/controllers/AuthControllerUnitTest.java
+++ b/src/test/java/com/stephensalano/fileflow_api/controllers/AuthControllerUnitTest.java
@@ -1,0 +1,94 @@
+package com.stephensalano.fileflow_api.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stephensalano.fileflow_api.dto.requests.RegisterRequest;
+import com.stephensalano.fileflow_api.entities.Account;
+import com.stephensalano.fileflow_api.entities.Role;
+import com.stephensalano.fileflow_api.entities.User;
+import com.stephensalano.fileflow_api.configs.security.JwtService;
+import com.stephensalano.fileflow_api.services.auth.AuthService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Unit test for AuthController
+ *
+ * This tests ONLY the controller layer by mocking its dependencies.
+ * It's fast because it doesn't start the full Spring application.
+ */
+@WebMvcTest(AuthController.class) // Only loads the web layer for AuthController
+public class AuthControllerUnitTest {
+
+    @Autowired
+    private MockMvc mockMvc; // Simulates HTTP requests to our controller
+
+    @MockitoBean // Creates a mock version of AuthService that we can control
+    private AuthService authService;
+
+    @MockitoBean // Mock the JwtService that AuthController depends on
+    private JwtService jwtService;
+
+    @Autowired
+    private ObjectMapper objectMapper; // Converts Java objects to JSON
+
+    @Test
+    @WithMockUser // This bypasses Spring Security for this test
+    void registerUser_WithValidData_ShouldReturnCreatedStatus() throws Exception {
+        // ARRANGE: Set up test data and mock behavior
+
+        // Create a sample registration request
+        RegisterRequest registerRequest = new RegisterRequest(
+                "test@example.com",
+                "testuser",
+                "Password123@",
+                "John",
+                "Doe" // This maps to 'secondName' field in your RegisterRequest
+        );
+
+        // Create a fake Account that our mock service will return
+        User mockUser = User.builder()
+                .firstName("John")
+                .secondName("Doe")
+                .build();
+
+        Account mockAccount = Account.builder()
+                .id(UUID.randomUUID())
+                .username("testuser")
+                .email("test@example.com")
+                .role(Role.USER)
+                .user(mockUser)
+                .build();
+
+        // Tell our mock AuthService what to return when registerUser is called
+        when(authService.registerUser(any(RegisterRequest.class)))
+                .thenReturn(mockAccount);
+
+        // ACT & ASSERT: Make the request and verify the response
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .with(csrf()) // Add CSRF token to bypass Spring Security's CSRF protection
+                        .contentType(MediaType.APPLICATION_JSON) // Tell Spring we're sending JSON
+                        .content(objectMapper.writeValueAsString(registerRequest))) // Convert request to JSON
+
+                // Verify the response
+                .andExpect(status().isCreated()) // HTTP 201
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON)) // Response is JSON
+                .andExpect(jsonPath("$.success").value(true)) // success field is true
+                .andExpect(jsonPath("$.message").value("Registration successful. Please check your email to verify your account."))
+                .andExpect(jsonPath("$.username").value("testuser"))
+                .andExpect(jsonPath("$.email").value("test@example.com"));
+    }
+}


### PR DESCRIPTION
This PR includes: 
1. Tests for auth endpoints for Register and login:
- Added integration tests to check the heath endpoint returns a 200 Ok
- Added unit tests to test for registration returns a 200 
- Added unit tests to test for login returns a 200
- Used `@WithMockUser` to make Spring treat the request as "authenticated"
- Used `with(csrf())` to bypass Spring Security's CSRF protection
- Used `@Mockitobean` which replaced `@MockBean` to mock services
- Used `ObjctMapper` to convert Java requests POJO to JSON objects
2. Few bug fixes:
- Corrected `AuthController` log spelling mistake from "Lgin"-> "Login"
- Removed pattern matcher for `@Email` annotation
- Included the `!` special symbol for Passwords